### PR TITLE
fix sampling statement for icar_normal

### DIFF
--- a/inst/stan/icar_binomial.stan
+++ b/inst/stan/icar_binomial.stan
@@ -24,7 +24,7 @@ transformed parameters {
 }
 model {
 #include parts/glm_model.stan
-  phi ~ icar_normal_lpdf(n, node1, node2);
+  phi ~ icar_normal(n, node1, node2);
   phi_scale ~ normal(0, phi_scale_prior);
   y ~ binomial(N, p); 
 }

--- a/inst/stan/icar_count.stan
+++ b/inst/stan/icar_count.stan
@@ -23,7 +23,7 @@ transformed parameters {
 
 model {
 #include parts/glm_model.stan
-  phi ~ icar_normal_lpdf(n, node1, node2);
+  phi ~ icar_normal(n, node1, node2);
   phi_scale ~ normal(0, phi_scale_prior);
   y ~ poisson_log(f); 
  }

--- a/inst/stan/parts/bym2_model.stan
+++ b/inst/stan/parts/bym2_model.stan
@@ -1,4 +1,4 @@
-  v ~ icar_normal_lpdf(n, node1, node2);
+  v ~ icar_normal(n, node1, node2);
   u ~ std_normal();
   logit_rho ~ std_normal();
   sigma_re ~ std_normal();


### PR DESCRIPTION
the call to the icar_normal distribution should be:
`phi ~ icar_normal(N, node1, node2)`, not `icar_normal_lpdf(...`.

back when this model was developed, the Stan compiler allowed this.
for later versions of Stan, this might result in a warning -
I think we're still allowing this as many people made the same mistake -
I naively thought that if you define a function, then you call it by its name.
but a sampling statement is not quite the same thing as a function call -
the Stan compiler maps the distribution name to a corresponding
distribution function, e.g., the sampling statement `y ~ normal(mu, sigma)`
is compiled to a call to the function `normal_lpdf(y | mu, sigma)`.
